### PR TITLE
Fixes mockito usage

### DIFF
--- a/app/src/test/java/com/scmspain/layertest/ExampleUnitTest.java
+++ b/app/src/test/java/com/scmspain/layertest/ExampleUnitTest.java
@@ -16,7 +16,7 @@ public class ExampleUnitTest {
   @Test
   public void layerTest () {
     Conversation conversation = Mockito.mock(Conversation.class);
-    Mockito.doReturn(3).when(conversation.getTotalMessageCount());
+    Mockito.doReturn(3).when(conversation).getTotalMessageCount();
 
     int messages = conversation.getTotalMessageCount();
 


### PR DESCRIPTION
Even without the `java.lang.VerifyError` the test won't pass because mockito is not being used correctly.
It's a very silly detail, I think the diff is self-explanatory ^^

With this change, the test should pass when the `java.lang.VerifyError` doesn't happen.